### PR TITLE
Rankscore normalization

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,19 @@
+# Developing
+
+## Host Requirements
+* Docker
+* package "build-essentials" for running Makefile
+
+## Run pytest
+There's support for pytest via Docker.
+
+Run the following to run pytest:
+
+```
+make test
+```
+
+## Running Genmod CLI
+```
+python3 -m genmod.commands.base
+```

--- a/Dockerfile.pytest
+++ b/Dockerfile.pytest
@@ -10,6 +10,7 @@ RUN pip3 install -r /genmod/requirements.txt
 COPY . /genmod
 
 ENV PYTHONPATH=/genmod
+ENV GENMOD_DOCKER_TEST=1
 
 WORKDIR /genmod
 

--- a/Dockerfile.pytest
+++ b/Dockerfile.pytest
@@ -1,0 +1,16 @@
+# Dockerfile to run genmod pytest suite
+FROM python:3.7@sha256:741bcc4e5900df61be4d3c1061ec1623074b50cce1a72269ffa87b9457406392
+
+RUN mkdir -p /genmod
+
+COPY requirements.txt /genmod/
+
+RUN pip3 install -r /genmod/requirements.txt
+
+COPY . /genmod
+
+ENV PYTHONPATH=/genmod
+
+WORKDIR /genmod
+
+ENTRYPOINT ["pytest"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: *
+
+DOCKER=DOCKER_BUILDKIT=1 docker
+
+all:
+	# Nothing to be built
+
+docker-build:
+	$(DOCKER) build -t genmod/test --force-rm=true --rm=true -f Dockerfile.pytest .
+
+test: docker-build
+	$(DOCKER) run -it -l genmod-test genmod/test
+
+test_%: docker-build
+	$(DOCKER) run -it -l genmod-test genmod/test -k $@
+
+docker-clean-images:
+	docker system prune

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ X	302253	.	CCCTCCTGCCCCT	C	100	PASS	MQ=1	GT:AD:GQ	0/0:10,10:60	0/1:10,10:60	1/1:
 MT	302253	.	CCCTCCTGCCCCT	C	100	PASS	MQ=1	GT:AD:GQ	0/0:10,10:60	0/1:10,10:60	1/1:10,10:60	0/0:10,10:60	1/1:10,10:60	1/1:10,10:60
 
 $ cat examples/test_vcf.vcf |\
->genmod annotate - --regions |\ 
+>genmod annotate - --annotate-regions |\
 >genmod models - --family_file examples/recessive_trio.ped > test_vcf_models_annotated.vcf
 
 $ cat test_vcf_models_annotated.vcf
@@ -128,7 +128,7 @@ Any annotation in the bed format can be used.
 To annotate the variants with user defined regions use
 
 ```bash
-$genmod annotate <vcf_file> -r/--regions --region-file path_to_regions.bed
+$genmod annotate <vcf_file> -r/--annotate-regions --region-file path_to_regions.bed
 
 ```
 

--- a/docs/commands/score-compounds.md
+++ b/docs/commands/score-compounds.md
@@ -1,0 +1,20 @@
+# Score Compounds
+
+This module performs ranking of compound variants.
+
+During the ranking of these compounds the rank score might be modified in place.
+See `genmod/score_variants/compound_scorer.py:L248`.
+
+## Rankscore Capping
+Since the rank scores are modified in place in this module, there's a risk
+that the modified rank score might fall outside the valid range of normalization
+bounds `(MIN, MAX)` that was established in the `score_variants` module.
+
+This applies to variants belonging to the lower range of rank scores.
+
+When this happens, the modified rank score is capped to  `(MIN, )` if it's of `RankScore` type
+or `(0, 1)` if it's of `RankScoreNormalized` type.
+
+In previous Genmod versions there were no such capping rule in effect.
+Earlier ranked variants from `compounds` module might show lower rank
+scores compared to this implementation.

--- a/docs/commands/score-variants.md
+++ b/docs/commands/score-variants.md
@@ -14,3 +14,6 @@ i. e `CategorySumMin = SUM(CategoryMin_n) for 0...n categories`.
 The same applies to `CategorySumMax = SUM(CategoryMax_n) for 0...n categories`.
 
 Refer to `score_variants.py::score()` method for implementation details.
+
+Additionally, also read in the `score-compounds.md` on compound scoring step that affects
+final rank score values.

--- a/docs/commands/score-variants.md
+++ b/docs/commands/score-variants.md
@@ -1,0 +1,16 @@
+# Score Variant
+
+## Rank Score Normalization
+
+The rank score is MAXMIN normalized into range (0, 1) according to the following formula:
+
+```
+RankScoreNormalized = (RankScore - CategorySumMin) / (CategorySumMax - CategorySumMin)
+```
+where `RankScore` is the sum of rank score across categories (including rules such as min, max, sum etc)
+`RankScore = SUM(Score_category_n) for 0...n categories`
+and `CategorySumMin` is the sum of minimal score values for all categories,
+i. e `CategorySumMin = SUM(CategoryMin_n) for 0...n categories`.
+The same applies to `CategorySumMax = SUM(CategoryMax_n) for 0...n categories`.
+
+Refer to `score_variants.py::score()` method for implementation details.

--- a/genmod/__init__.py
+++ b/genmod/__init__.py
@@ -1,7 +1,14 @@
 from __future__ import (print_function, absolute_import)
 from logging import getLogger
-from pkg_resources import get_distribution
+from pkg_resources import get_distribution, DistributionNotFound
+from os import environ
 
 logger = getLogger(__name__)
 
-__version__ = get_distribution("genmod").version
+try:
+    __version__ = get_distribution("genmod").version
+except DistributionNotFound as error:
+    # Genmod is not installed (as the case for docker test suite)
+    if 'GENMOD_DOCKER_TEST' not in environ.keys():
+        raise error
+    __version__ = '-1.-1.-1'

--- a/genmod/commands/annotate_variant.py
+++ b/genmod/commands/annotate_variant.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 @click.command('annotate', short_help="Annotate vcf variants")
 @variant_file
-@click.option('-r', '--regions', '--annotate_regions','--annotate-regions', 
+@click.option('-r', '--annotate_regions','--annotate-regions', '--regions',
                 is_flag=True,
                 help='Annotate what regions a variant belongs to (eg. genes).'
 )

--- a/genmod/commands/score_compounds.py
+++ b/genmod/commands/score_compounds.py
@@ -79,6 +79,13 @@ def compound(context, variant_file, silent, outfile, vep, processes, temp_dir):
     header_line = head.header
     individuals = head.individuals
 
+    add_metadata(head,
+                 'info',
+                 'CompoundsNormalized',
+                 annotation_number='.',
+                 entry_type='String',
+                 description='Rank score as provided by compound analysis, based on RankScoreNormalized. family_id:rank_score')
+
     ###################################################################
     ### The task queue is where all jobs(in this case batches that  ###
     ### represents variants in a region) is put. The consumers will ###

--- a/genmod/score_variants/__init__.py
+++ b/genmod/score_variants/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from .score_function import ScoreFunction
 from .config_parser import ConfigParser
-from .score_variant import get_category_score
+from .score_variant import get_category_score, as_normalized_max_min
 from .compound_scorer import CompoundScorer
 from .check_plugins import check_plugins
+from .rank_score_variant_definitions import RANK_SCORE_TYPES, RANK_SCORE_TYPE_NAMES

--- a/genmod/score_variants/__init__.py
+++ b/genmod/score_variants/__init__.py
@@ -2,6 +2,6 @@ from __future__ import absolute_import
 
 from .score_function import ScoreFunction
 from .config_parser import ConfigParser
-from .score_variant import score_variant, get_category_score
+from .score_variant import get_category_score
 from .compound_scorer import CompoundScorer
 from .check_plugins import check_plugins

--- a/genmod/score_variants/cap_rank_score_to_min_bound.py
+++ b/genmod/score_variants/cap_rank_score_to_min_bound.py
@@ -1,0 +1,27 @@
+from genmod.score_variants.score_variant import MIN_SCORE_NORMALIZED
+from genmod.score_variants.rank_score_variant_definitions import RANK_SCORE_TYPE_NAMES
+
+
+def cap_rank_score_to_min_bound(rank_score_type: str,
+                                rank_score,
+                                min_rank_score_value: float) -> float:
+    """
+    Caps rank_score to fall withing MIN bound of normalized rank score, if it's outside valid range.
+    Args:
+        rank_score_type: Type of rank score
+        rank_score: The value to bounds check
+        min_rank_score_value: Minimum allowed bound according to rank score normalization
+    Returns:
+        Bounds capped rank score, either to min_rank_score_value (if RankScore)
+        or MIN_SCORE_NORMALIZED if RankScoreNormalized type.
+    """
+
+    if rank_score_type not in set(RANK_SCORE_TYPE_NAMES):
+        raise ValueError(f'Unknown rank score type {rank_score_type}')
+
+    if rank_score_type == 'RankScoreNormalized':
+        min_rank_score_value = MIN_SCORE_NORMALIZED
+
+    if rank_score < min_rank_score_value:
+        return min_rank_score_value
+    return rank_score

--- a/genmod/score_variants/compound_scorer.py
+++ b/genmod/score_variants/compound_scorer.py
@@ -16,12 +16,72 @@ from __future__ import (division, print_function)
 import sys
 import os
 import logging
-
+from typing import Dict, Tuple, Union, List
 from multiprocessing import Process
 
 from genmod.vcf_tools import (replace_vcf_info, add_vcf_info)
 
+from genmod.score_variants.score_variant import as_normalized_max_min, MIN_SCORE_NORMALIZED, MAX_SCORE_NORMALIZED
+from genmod.score_variants.rank_score_variant_definitions import RANK_SCORE_TYPE_NAMES
+
 logger = logging.getLogger(__name__)
+
+
+def get_rank_score(rank_score_type: str,
+                   threshold: Union[int, float],
+                   min_rank_score_value: float,
+                   max_rank_score_value: float) -> Union[int, float]:
+    """
+    Return raw rank score or normalized rank score.
+
+    Args:
+        rank_score_type: Type according to RANK_SCORE_TYPE_NAMES
+        threshold: A rank score like value
+        min_rank_score_value: input to as_normalized_max_min
+        max_rank_score_value: input to as_normalized_max_min
+    Returns:
+        A rank score like value, possibly normalized
+    """
+    if rank_score_type == 'RankScore':
+        return threshold
+    elif rank_score_type == 'RankScoreNormalized':
+        # Normalize raw rank score
+        return as_normalized_max_min(score=float(threshold),
+                                     min_score_value=min_rank_score_value,
+                                     max_score_value=max_rank_score_value)
+    raise ValueError('Unknown RANK_SCORE_TYPE_NAMES config', rank_score_type)
+
+
+def get_rank_score_as_magnitude(rank_score_type: str,
+                                rank_score: Union[int, float],
+                                min_rank_score_value: float,
+                                max_rank_score_value: float) -> float:
+    """
+    Returns rank score as a magnitude (delta), to make the rank score
+    suitable for addition/subtraction operations.
+
+    In case of raw rank score, return the input value as the magnitude.
+
+    In case of normalized rank score, return the input value as the
+    percentage of the rank score dynamic range.
+
+    Args:
+        rank_score_type: Type according to RANK_SCORE_TYPE_NAMES
+        rank_score: A rank score like value, to be used in an addition/subtraction operation
+        min_rank_score_value: input to as_normalized_max_min
+        max_rank_score_value: input to as_normalized_max_min
+    Returns:
+        A value, magnitude, compatible with raw or normalized rank score values
+
+    """
+    if rank_score_type == 'RankScore':
+        return rank_score
+    elif rank_score_type == 'RankScoreNormalized':
+        normalized_rank_score: float = rank_score / (max_rank_score_value - min_rank_score_value)
+        if not (MIN_SCORE_NORMALIZED <= normalized_rank_score <= MAX_SCORE_NORMALIZED):
+            raise ValueError(f'Failed to normalize to within expected bounds {normalized_rank_score}')
+        return normalized_rank_score
+    raise ValueError(f'Unknown rank score type {rank_score_type}')
 
 class CompoundScorer(Process):
     """
@@ -62,7 +122,28 @@ class CompoundScorer(Process):
             self.models = ['AR_comp', 'AR_comp_dn', 'AD', 'AD_dn']
         else:
             self.models = ['AR_comp', 'AR_comp_dn']
-            
+
+    @staticmethod
+    def _get_rankscore_normalization_bounds(variant_batch: Dict[str, Dict]) -> Dict[str, Tuple]:
+        """
+        For all variants in a variant batch, find the rank score normalization
+        min-max bounds.
+
+        Returns:
+            A dict containing tuple min-max keyed on variant id
+        """
+        variant_rankscore_normalization_bounds: dict = {}
+        for variant_id in variant_batch:
+            entry_minmax: List[str] = variant_batch[variant_id]['info_dict']['RankScoreMinMax'].split(':')
+            rankscore_normalization_min_max: tuple = (float(entry_minmax[1]), float(entry_minmax[2]))
+            if not rankscore_normalization_min_max[0] <= rankscore_normalization_min_max[1]:
+                raise ValueError(f'Invalid min-max normalization value expected MIN-MAX \
+                {rankscore_normalization_min_max}')
+            if variant_id in variant_rankscore_normalization_bounds.keys():
+                raise KeyError(f'Cannot add variant ID to normalization data dict since it\'s already present \
+                               {variant_id}, {variant_rankscore_normalization_bounds}')
+            variant_rankscore_normalization_bounds.update({variant_id: rankscore_normalization_min_max})
+        return variant_rankscore_normalization_bounds
 
     def run(self):
         """Run the consuming"""
@@ -83,108 +164,133 @@ class CompoundScorer(Process):
             # This is a dictionary on the form {'variant_id: rank_score}
             rank_scores = {}
             # We are now going to score the compounds
-            for variant_id in variant_batch:
-                # First we store the scores for each variant in a dictionary
-                variant = variant_batch[variant_id]
-                rank_score_entry = variant['info_dict'].get('RankScore', '')
-                
-                # We need to loop through the families
-                # This entry looks like <family_id>:<rank_score>, <family_id>:<rank_score>
-                for family_rank_score in rank_score_entry.split(','):
-                    family_rank_score = family_rank_score.split(':')
-                    
-                    #TODO check if correct family id
-                    # Right now we assume that there is only one family in the vcf
-                    family_id = family_rank_score[0]
-                    rank_score = int(family_rank_score[-1])
-                    
-                    rank_scores[variant_id] = rank_score
+            for rank_score_type in RANK_SCORE_TYPE_NAMES:
+                # Prepare rank_scores dict to contain raw RankScore and RankScoreNormalized compound scores
+                rank_scores.update({rank_score_type: dict()})
+
+                for variant_id in variant_batch:
+                    # First we store the scores for each variant in a dictionary
+                    variant = variant_batch[variant_id]
+                    rank_score_entry = variant['info_dict'].get(f'{rank_score_type}', '')
+
+                    # We need to loop through the families
+                    # This entry looks like <family_id>:<rank_score>, <family_id>:<rank_score>
+                    for family_rank_score in rank_score_entry.split(','):
+                        family_rank_score = family_rank_score.split(':')
+
+                        #TODO check if correct family id
+                        # Right now we assume that there is only one family in the vcf
+                        family_id = family_rank_score[0]
+                        rank_score = float(family_rank_score[-1])
+
+                        rank_scores[rank_score_type][variant_id] = rank_score
+
+            # Per variant, find rank score max min values used for normalization
+            variant_rankscore_normalization_bounds: Dict[str, Tuple] = \
+                self._get_rankscore_normalization_bounds(variant_batch)
             
-            #We now have a dictionary with variant ids and rank scores
+            #We now have a dictionary with variant ids and rank scores, per rank_score_type
             for variant_id in variant_batch:
                 # If the variants only follow AR_comp (and AD for single individual families)
                 # we want to pennalise the score if the compounds have low scores
                 variant = variant_batch[variant_id]
                 raw_compounds = variant['info_dict'].get('Compounds', None)
-                
-                if raw_compounds:
-                    logger.debug("Scoring compound for variant %s" % variant_id)
-                    variant = variant_batch[variant_id]
-                    #Variable to see if we should correct the rank score
-                    correct_score = True
-                    # First we check if the rank score should be corrected:
-                    for family in variant['info_dict'].get('GeneticModels', '').split(','):
-                        for model in family.split(':')[-1].split('|'):
-                            # If the variant follows any model more than the specified it should
-                            # not be corrected
-                            if model not in self.models:
-                                correct_score = False
-                    
-                    logger.debug("Setting correct_score to {0}".format(correct_score))
-                    
-                    current_rank_score = rank_scores[variant_id]
-                    
-                    logger.debug("Current rank score is {0}".format(current_rank_score))
-                    
-                    scored_compound_list = []
-                    only_low = True
-                    
-                    # One entry per family, splitted on ','
-                    # family_id and compounds splitted with ':'
-                    # list of compounds splitted on '|'
-                    
-                    #TODO Only checks first family now
-                    family_compound_entry = raw_compounds.split(',')[0]
-                    splitted_entry = family_compound_entry.split(':')
-                    compound_family_id = splitted_entry[0]
-                    compound_list = splitted_entry[-1].split('|')
-                    
-                    logger.debug("Checking compounds for family {0}".format(
-                        compound_family_id))
-                    
-                    #Loop through compounds to check if they are only low scored
-                    for compound_id in compound_list:
-                        compound_rank_score = rank_scores[compound_id]
-                        if compound_rank_score > 9:
-                            only_low = False
-                    logger.debug("Setting only_low to {0}".format(only_low))
-                    
-                    if (correct_score and only_low):
-                        logger.debug("correcting rank score for {0}".format(
-                            variant_id))
-                        current_rank_score -= 6
-                        
-                    for compound_id in compound_list:
-                        logger.debug("Checking compound {0}".format(compound_id))
-                        compound_rank_score = rank_scores[compound_id]
-                        # This is the combined score for current variant and 
-                        # its compound:
-                        compound_score = current_rank_score + compound_rank_score
-                        # This is the new compound
-                        new_compound = "{0}>{1}".format(compound_id, compound_score)
-                        scored_compound_list.append(new_compound)
+                for rank_score_type in RANK_SCORE_TYPE_NAMES:
+                    if raw_compounds:
+                        logger.debug("Scoring compound for variant %s" % variant_id)
+                        #Variable to see if we should correct the rank score
+                        correct_score = True
+                        # First we check if the rank score should be corrected:
+                        for family in variant['info_dict'].get('GeneticModels', '').split(','):
+                            for model in family.split(':')[-1].split('|'):
+                                # If the variant follows any model more than the specified it should
+                                # not be corrected
+                                if model not in self.models:
+                                    correct_score = False
 
-                    new_compound_string = "{0}:{1}".format(
-                        compound_family_id, '|'.join(scored_compound_list))
+                        logger.debug("Setting correct_score to {0}".format(correct_score))
 
-                    new_rank_score_string = "{0}:{1}".format(compound_family_id, current_rank_score)
-                    
-                    # variant['info_dict']['IndividualRankScore'] = current_rank_score_string
-                    variant['info_dict']['RankScore'] = new_rank_score_string
-                    variant['info_dict']['Compounds'] = new_compound_string
-                    
-                    variant = replace_vcf_info(
-                        keyword = 'RankScore',
-                        annotation = new_rank_score_string, 
-                        variant_dict=variant
-                    )
-                    
-                    variant = replace_vcf_info(
-                        keyword = 'Compounds',
-                        annotation = new_compound_string, 
-                        variant_dict=variant
-                    )
+                        current_rank_score = rank_scores[rank_score_type][variant_id]
+
+                        logger.debug("Current rank score is {0}".format(current_rank_score))
+
+                        scored_compound_list = []
+                        only_low = True
+
+                        # One entry per family, splitted on ','
+                        # family_id and compounds splitted with ':'
+                        # list of compounds splitted on '|'
+
+                        #TODO Only checks first family now
+                        family_compound_entry = raw_compounds.split(',')[0]
+                        splitted_entry = family_compound_entry.split(':')
+                        compound_family_id = splitted_entry[0]
+                        compound_list = splitted_entry[-1].split('|')
+
+                        logger.debug("Checking compounds for family {0}".format(
+                            compound_family_id))
+
+                        #Loop through compounds to check if they are only low scored
+                        for compound_id in compound_list:
+                            compound_rank_score = rank_scores[rank_score_type][compound_id]
+                            if compound_rank_score > get_rank_score(rank_score_type=rank_score_type,
+                                                                    threshold=9,
+                                                                    min_rank_score_value=variant_rankscore_normalization_bounds[variant_id][0],
+                                                                    max_rank_score_value=variant_rankscore_normalization_bounds[variant_id][1]
+                                                                    ):
+                                only_low = False
+                        logger.debug("Setting only_low to {0}".format(only_low))
+
+                        if (correct_score and only_low):
+                            logger.debug("correcting rank score for {0}".format(
+                                variant_id))
+                            current_rank_score -= get_rank_score_as_magnitude(rank_score_type=rank_score_type,
+                                                                              rank_score=6,
+                                                                              min_rank_score_value=variant_rankscore_normalization_bounds[variant_id][0],
+                                                                              max_rank_score_value=variant_rankscore_normalization_bounds[variant_id][1]
+                                                                              )
+
+                        for compound_id in compound_list:
+                            logger.debug("Checking compound {0}".format(compound_id))
+                            compound_rank_score = rank_scores[rank_score_type][compound_id]
+                            # This is the combined score for current variant and
+                            # its compound:
+                            compound_score = current_rank_score + compound_rank_score
+                            # This is the new compound
+                            new_compound = "{0}>{1}".format(compound_id, compound_score)
+                            scored_compound_list.append(new_compound)
+
+                        new_compound_string = "{0}:{1}".format(
+                            compound_family_id, '|'.join(scored_compound_list))
+
+                        new_rank_score_string = "{0}:{1}".format(compound_family_id, current_rank_score)
+
+                        # variant['info_dict']['IndividualRankScore'] = current_rank_score_string
+                        variant['info_dict'][f'{rank_score_type}'] = new_rank_score_string
+                        variant['info_dict'][f'Compounds{rank_score_type.strip("RankScore")}'] = new_compound_string
+
+                        variant = replace_vcf_info(
+                            keyword=f'{rank_score_type}',
+                            annotation = new_rank_score_string,
+                            variant_dict=variant
+                        )
+
+                        # CompoundsNormalized is not previously added to VCF.
+                        # For this case, perform an VCF INFO ADD operation, rather than a REPLACE
+                        keyword_compounds = f'Compounds{rank_score_type.strip("RankScore")}'
+                        fn_add_replace_vcf_info = replace_vcf_info
+                        if not (keyword_compounds in variant['INFO'] and
+                                keyword_compounds in variant['info_dict']):
+                            # In case INFO subfield is not previously added to VCF,
+                            # there's a need to do so now.
+                            fn_add_replace_vcf_info = add_vcf_info
+                        variant = fn_add_replace_vcf_info(
+                            keyword=keyword_compounds,
+                            annotation=new_compound_string,
+                            variant_dict=variant
+                        )
                 logger.debug("Putting variant in results_queue")
+
                 self.results_queue.put(variant)
             
             self.task_queue.task_done()

--- a/genmod/score_variants/compound_scorer.py
+++ b/genmod/score_variants/compound_scorer.py
@@ -23,6 +23,7 @@ from genmod.vcf_tools import (replace_vcf_info, add_vcf_info)
 
 from genmod.score_variants.score_variant import as_normalized_max_min, MIN_SCORE_NORMALIZED, MAX_SCORE_NORMALIZED
 from genmod.score_variants.rank_score_variant_definitions import RANK_SCORE_TYPE_NAMES
+from genmod.score_variants.cap_rank_score_to_min_bound import cap_rank_score_to_min_bound
 
 logger = logging.getLogger(__name__)
 
@@ -249,6 +250,12 @@ class CompoundScorer(Process):
                                                                               min_rank_score_value=variant_rankscore_normalization_bounds[variant_id][0],
                                                                               max_rank_score_value=variant_rankscore_normalization_bounds[variant_id][1]
                                                                               )
+                            # In case the current_rank_score falls outside normalization bounds after modification,
+                            # cap it to within the MIN normalization bound.
+                            current_rank_score = cap_rank_score_to_min_bound(rank_score_type=rank_score_type,
+                                                                             rank_score=current_rank_score,
+                                                                             min_rank_score_value=variant_rankscore_normalization_bounds[variant_id][0]
+                                                                             )
 
                         for compound_id in compound_list:
                             logger.debug("Checking compound {0}".format(compound_id))

--- a/genmod/score_variants/rank_score_variant_definitions.py
+++ b/genmod/score_variants/rank_score_variant_definitions.py
@@ -1,0 +1,8 @@
+from typing import Dict, List
+
+# Types of rank scores provided by scoring, raw and normalized rank scores
+RANK_SCORE_TYPES: Dict[str, str]= {
+    'RankScore': 'The rank score for this variant in this family. family_id:rank_score.',
+    'RankScoreNormalized': 'The normalized rank score in range(0, 1) for this variant in this family. family_id:rank_score.'
+}
+RANK_SCORE_TYPE_NAMES: List[str] = list(RANK_SCORE_TYPES.keys())

--- a/genmod/score_variants/score_variant.py
+++ b/genmod/score_variants/score_variant.py
@@ -85,31 +85,4 @@ def get_category_score(variant, category, config_parser, csq_format=None):
         logger.debug("No scores found for category {0}".format(category))
     
     return category_score
-    
 
-def score_variant(variant, config_parser, csq_format=None):
-    """Score a variant line
-    
-        Args:
-            variant (dict): A variant dictionary
-            config_parser (ConfigParser): A config parser object with score functions
-        Returns:
-            rank_score (float): The rank score for this variant
-    """
-    
-    rank_score = 0
-    
-    for category in config_parser.categories:
-        logger.debug("Checking scores for category {0}".format(category))
-        category_score = get_category_score(
-            variant = variant,
-            category = category,
-            config_parser = config_parser,
-            csq_format = csq_format
-        )
-
-        logger.debug("Adding category score {0} to rank_score".format(category_score))
-        rank_score += category_score
-        logger.debug("Updating rank score to {0}".format(rank_score))
-
-    return rank_score

--- a/genmod/score_variants/score_variant.py
+++ b/genmod/score_variants/score_variant.py
@@ -4,10 +4,15 @@ Score a variant line based on the score functions in config_parser
 """
 
 import logging
+from typing import Any, Tuple, List
 
 logger = logging.getLogger(__name__)
 
-def get_plugin_score(variant, plugin_name, config_parser, csq_format=None):
+MIN_SCORE_NORMALIZED: float = 0.0
+MAX_SCORE_NORMALIZED: float = 1.0
+
+
+def get_plugin_score(variant, plugin_name, config_parser, csq_format=None) -> Tuple[Any, float, float]:
     """Return the score found for a plugin
     
         Args:
@@ -30,59 +35,111 @@ def get_plugin_score(variant, plugin_name, config_parser, csq_format=None):
     # Score is allways a number
     score = score_function.get_score(value)
     logger.debug("Score is {0} for plugin {1}".format(score, plugin_name))
-    
-    return score
 
-def get_category_score(variant, category, config_parser, csq_format=None):
-    """Return the score for a given category
+    plugin_score_min: float = score_function.score_min
+    plugin_score_max: float = score_function.score_max
+    logger.debug(f'Minmax scores for plugin {plugin_name} is ({plugin_score_min},{plugin_score_max})')
     
+    return score, plugin_score_min, plugin_score_max
+
+
+def get_category_score(variant, category, config_parser, csq_format=None) -> Tuple[int, float, float]:
+    """Return the score for a given category.
+
+       A category (such as 'allele_frequency') groups multiple plugin scores.
+       This method selects final score based on category_aggregation [Categories]
+       rule (see genmod_example.ini)
+
         Args:
             variant (dict): A variant dictionary
             category (str): A score category
             config_parser (ConfigParser): A config parser object with score functions
         Returns:
-            category_score (float): The rank score for this variant
+            category_score, sum of min and max scores for this category
     """
-    
+
     category_score = 0
-    
+
     logger.debug("Checking scores for category {0}".format(category))
     #We save all the scores for a category
     category_aggregate = config_parser.categories[category]['category_aggregation']
     category_scores = []
-    
+    category_score_mins: List[float] = []
+    category_score_maxs: List[float] = []
+
     for plugin_name in config_parser.categories[category]['plugins']:
-        category_scores.append(get_plugin_score(
-            variant = variant, 
-            plugin_name = plugin_name, 
+        plugin_score, plugin_score_min, plugin_score_max = get_plugin_score(
+            variant = variant,
+            plugin_name = plugin_name,
             config_parser = config_parser,
             csq_format = csq_format
             )
-        )
+        category_scores.append(plugin_score)
+        # Add the maximal and minimal score points that can be provided for this category
+        category_score_mins.append(plugin_score_min)
+        category_score_maxs.append(plugin_score_max)
+
+    # Provide default plugin bounds in case there were no plugins in category
+    category_score_min: float = 0.0
+    category_score_max: float = 0.0
 
     if category_scores:
-    
+
         if category_aggregate == 'max' and category_scores:
             logger.debug("Take the max score for category {0}".format(
                 category))
             category_score = max(category_scores)
+            category_score_min = max(category_score_mins)
+            category_score_max = max(category_score_maxs)
             logger.debug("Max value is {0}".format(
                 category_score))
         elif category_aggregate == 'min' and category_scores:
             logger.debug("Take the min score for category {0}".format(
                 category))
             category_score = min(category_scores)
+            category_score_min = min(category_score_mins)
+            category_score_max = min(category_score_maxs)
             logger.debug("Min value is {0}".format(
                 category_score))
         elif category_aggregate == 'sum' and category_scores:
             logger.debug("Take the sum of scores score for category {0}".format(
                 category))
             category_score = sum(category_scores)
+            category_score_min = sum(category_score_mins)
+            category_score_max = sum(category_score_maxs)
             logger.debug("Sum of scores is {0}".format(
                 category_score))
-        
+
     else:
         logger.debug("No scores found for category {0}".format(category))
-    
-    return category_score
 
+    if not (category_score_min <= category_score <= category_score_max):
+        raise ValueError('Category score outside expected category score range',
+                          category_score_min, category_score, category_score_max)
+    return category_score, category_score_min, category_score_max
+
+
+def as_normalized_max_min(score: float,
+                          min_score_value: float,
+                          max_score_value: float) -> float:
+    """
+    Performs max-min normalization of score to range (0, 1).
+    Args:
+        score: Rank score
+        min_score_value: Lower bound on score
+        max_score_value: Upper bound on score
+    Returns:
+        Score in range (0, 1)
+    """
+    for key, value in {'score': score,
+                       'min_score_value': min_score_value,
+                       'max_score_value': max_score_value}.items():
+        if not isinstance(value, float):
+            raise TypeError(f'Bad type {key} {type(value)} {value}')
+    if not max_score_value >= min_score_value:
+        raise ValueError('Inverted minmax values for normalization', max_score_value, min_score_value)
+    score_normalized: float = (score - min_score_value) / (max_score_value - min_score_value)
+    if not (MIN_SCORE_NORMALIZED <= score_normalized <= MAX_SCORE_NORMALIZED):
+        raise ValueError('Failed to normalize to within expected bounds',
+                                        min_score_value, max_score_value, score, score_normalized)
+    return score_normalized

--- a/genmod/utils/get_priority.py
+++ b/genmod/utils/get_priority.py
@@ -1,5 +1,5 @@
 import logging
-
+from genmod.score_variants import RANK_SCORE_TYPE_NAMES
 
 def get_chromosome_priority(chrom, chrom_dict={}):
     """
@@ -35,7 +35,7 @@ def get_chromosome_priority(chrom, chrom_dict={}):
     
     return priority
 
-def get_rank_score(variant_line=None, variant_dict=None, family_id=0):
+def get_rank_score(variant_line=None, variant_dict=None, family_id=0, rank_score_type: str = 'RankScore'):
     """
     Return the rank score priority for a certain family.
     
@@ -45,10 +45,14 @@ def get_rank_score(variant_line=None, variant_dict=None, family_id=0):
         variant_line (str): A vcf variant line
         variant_dict (dict): A variant dictionary
         family_id (str): A family id
+        rank_score_type(str): Return rank score based on raw or normalized format
+        See the genmod.score_variants.rank_score_variant_definitions for more info.
     
     Return:
         rank_score (str): The rank score for this variant
     """
+    if rank_score_type not in RANK_SCORE_TYPE_NAMES:
+        raise ValueError('Unknown rank_score_type', rank_score_type)
     
     rank_score = -100
     raw_entry = None
@@ -62,12 +66,12 @@ def get_rank_score(variant_line=None, variant_dict=None, family_id=0):
             if len(info_annotation) == 2:
                 key = info_annotation[0]
                 value = info_annotation[1]
-            if key == "RankScore":
+            if key == rank_score_type:
                 raw_entry = value
                 break
     
     elif variant_dict:
-        raw_entry = variant_dict['info_dict'].get('RankScore')
+        raw_entry: str = variant_dict['info_dict'].get(rank_score_type)
     
     if raw_entry:
         for family_annotation in raw_entry.split(','):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+# pytest.ini
+[pytest]
+minversion = 6.0
+addopts = -ra -q
+testpaths = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-ped_parser >= 1.6.2
-pytabix
-pytest
-interval_tree >= 0.3.4
-click
-configobj
-intervaltree
-extract_vcf >= 0.4.2
-vcftoolbox > 1.3
+ped_parser == 1.6.6
+pytabix == 0.1
+pytest == 7.3.1
+interval_tree == 0.3.4
+click == 8.1.3
+configobj == 5.0.8
+intervaltree == 3.1.0
+extract_vcf == 0.5
+vcftoolbox == 1.5.1

--- a/tests/score_variants/test_category_score.py
+++ b/tests/score_variants/test_category_score.py
@@ -1,0 +1,297 @@
+import pytest
+from typing import Union, Dict, Any
+from tempfile import NamedTemporaryFile
+from configobj import ConfigObj
+
+from genmod.score_variants import ConfigParser
+from genmod.vcf_tools import get_info_dict
+from genmod.score_variants.score_variant import get_category_score
+
+
+class ConfigObjWithNamedTemporaryFile(ConfigObj):
+    """
+    Class that wraps a NamedTemporaryFile inside a ConfigObject
+    """
+    def __init__(self, named_temporary_file: NamedTemporaryFile, *args, **kwargs):
+        """
+        Args:
+            named_temporary_file: A tmp file that will eventually contain the written config
+        """
+        super().__init__(*args, **kwargs)
+        self._file_pointer: NamedTemporaryFile = named_temporary_file
+        self.filename: str = named_temporary_file.name
+
+    def add_category(self,
+                     name: str,
+                     aggregation_mode: str):
+        """
+        Add a category to config file
+        Args:
+            name: Category name
+            aggregation_mode: mode of score aggregation for this category
+        Returns:
+            self for chaining
+        """
+        self['Categories'][name]: Dict = {}
+        self['Categories'][name]['category_aggregation'] = aggregation_mode
+        self.write()
+        return self
+
+    def add_plugin(self,
+                   category: str,
+                   plugin_name: str,
+                   score_categories: Dict[str, Dict[str, float]],
+                   info_key: str,
+                   not_reported_score: float = 0.0,
+                   field: str = 'INFO',
+                   data_type: str = 'float',
+                   record_rule: str = 'max',
+                   separators: str = ',',
+                   ):
+        """
+        Add plugin definition to scoring config.
+        Arguments is 1:1 mapped to scoring config file.
+
+        For the remaining arguments, please refer to the scoring config spec.
+        Args:
+            category: Plugin category this plugin belong sto
+            plugin_name: Name of plugin
+            score_categories: A map containing a range, example:
+              {'rare': {'score': 2.0, 'lower': 0.01, 'upper': 0.05}}
+            which maps to:
+              [[rare]]
+                score = 1
+                lower = 0.01
+                upper = 1.0
+            info_key: Mapping key that holds the plugin input value used for scoring
+
+        Returns:
+            self for chaining
+        """
+        self[plugin_name]: Dict = {}
+        self[plugin_name]['field'] = field
+        self[plugin_name]['data_type'] = data_type
+        self[plugin_name]['category'] = category
+        self[plugin_name]['record_rule'] = record_rule
+        self[plugin_name]['separators'] = separators
+        self[plugin_name]['info_key'] = info_key
+
+        self[plugin_name]['not_reported']: Dict = {}
+        self[plugin_name]['not_reported']['score'] = not_reported_score
+
+        for score_category in score_categories.keys():
+            self[plugin_name][score_category]: Dict = {}
+
+        for score_category, score_range in score_categories.items():
+            for score_range_key, score_range_value in score_range.items():
+                self[plugin_name][score_category][score_range_key] = score_range_value
+        self.write()
+        return self
+
+
+def set_info_dict_in_variant(variant: Dict[str, str]) -> Dict[str, Union[str, Any]]:
+    """
+    Create info_dict attribute required by get_category_score.
+    Args:
+        variant: A variant dict, example:
+            variant = {'CHROM': '1',
+                       'POS': '1',
+                       'INFO': 'plugin_a=0.01;plugin_b=1.0'
+                       }
+    Returns:
+        variant with ['info_dict'] attribute
+    """
+    variant['info_dict']: Dict[str, str] = get_info_dict(variant['INFO'])
+    return variant
+
+
+@pytest.fixture
+def config_file() -> ConfigObjWithNamedTemporaryFile:
+    """
+    Provide a scoring config file for tests
+    Returns:
+        A minimal scoring config file as ConfigObjWithNamedTemporaryFile
+    """
+    named_temporary_file: NamedTemporaryFile = NamedTemporaryFile(dir='/tmp')
+    config: ConfigObjWithNamedTemporaryFile = \
+        ConfigObjWithNamedTemporaryFile(named_temporary_file=named_temporary_file)
+    config['Version'] = {}
+    config['Version']['version'] = 0.1
+    config['Version']['name'] = 'genmod example'
+    config['Categories'] = {}
+    return config
+
+
+@pytest.fixture
+def variant_0():
+    variant = {
+        'CHROM': '1',
+        'POS': '1',
+        'INFO': 'plugin_a=0.01;plugin_b=5.0'
+    }
+    variant = set_info_dict_in_variant(variant)
+    return variant
+
+
+@pytest.mark.parametrize('aggregation_mode,expected',
+                         [('sum', (2, 0, 2)),
+                          ('max', (2, 0, 2)),
+                          ('min', (2, 0, 2))])
+def test_single_category_single_plugin(config_file, variant_0, aggregation_mode, expected):
+    """
+    Test with a single category.
+    """
+    # GIVEN a scoring config in mode aggregation_mode
+    config_file.add_category('CategoryA', aggregation_mode)
+    config_file.add_plugin('CategoryA',
+                           'PluginA',
+                           {'rare': {'score': 2.0, 'lower': 0.01, 'upper': 0.05}},
+                           'plugin_a')
+    config_parser: ConfigParser = ConfigParser(config_file.filename)
+    # WHEN scoring a variant
+    score, min, max = get_category_score(variant=variant_0,
+                                         category='CategoryA',
+                                         config_parser=config_parser)
+    # THEN expect proper score and min max bounds
+    assert score == expected[0]
+    assert min == expected[1]
+    assert max == expected[2]
+
+
+@pytest.mark.parametrize('aggregation_mode,expected',
+                         [('sum', (2, -5, 2)),
+                          ('max', (2, -5, 2)),
+                          ('min', (2, -5, 2))])
+def test_single_category_single_plugin_notreported(config_file, variant_0, aggregation_mode, expected):
+    """
+    Test with a single category, with a custom not reported score.
+    """
+    # GIVEN a scoring config in mode aggregation_mode
+    config_file.add_category('CategoryA', aggregation_mode)
+    config_file.add_plugin('CategoryA',
+                           'PluginA',
+                           {'rare': {'score': 2.0, 'lower': 0.01, 'upper': 0.05}},
+                           'plugin_a',
+                           not_reported_score=-5)
+    config_parser: ConfigParser = ConfigParser(config_file.filename)
+    # WHEN scoring a variant
+    score, min, max = get_category_score(variant=variant_0,
+                                         category='CategoryA',
+                                         config_parser=config_parser)
+    # THEN expect proper score and min max bounds
+    assert score == expected[0]
+    assert min == expected[1]
+    assert max == expected[2]
+
+
+@pytest.mark.parametrize('aggregation_mode,expected',
+                         [('sum', (3, 0, 3)),
+                          ('max', (2, 0, 2)),
+                          ('min', (1, 0, 1))])
+def test_single_category_two_plugin(config_file, variant_0, aggregation_mode, expected):
+    """
+    Test two categories.
+    """
+    # GIVEN a scoring config in mode aggregation_mode
+    config_file.add_category('CategoryA', aggregation_mode)
+    config_file.add_plugin('CategoryA',
+                           'PluginA',
+                           {'rare': {'score': 2.0, 'lower': 0.01, 'upper': 0.05}},
+                           'plugin_a')
+    config_file.add_plugin('CategoryA',
+                           'PluginB',
+                           {'rare': {'score': 1.0, 'lower': 4.0, 'upper': 6.0}},
+                           'plugin_b')
+    config_parser: ConfigParser = ConfigParser(config_file.filename)
+    # WHEN scoring a variant
+    score, min, max = get_category_score(variant=variant_0,
+                                         category='CategoryA',
+                                         config_parser=config_parser)
+    # THEN expect proper score and min max bounds
+    assert score == expected[0]
+    assert min == expected[1]
+    assert max == expected[2]
+
+
+@pytest.mark.parametrize('aggregation_mode,expected',
+                         [('sum', (-3, -5, 2)),
+                          ('max', (2, 0, 2)),
+                          ('min', (-5, -5, 0))])
+def test_single_category_two_plugin(config_file, variant_0, aggregation_mode, expected):
+    """
+    Test two categories, negative score range.
+    """
+    # GIVEN a scoring config in mode aggregation_mode
+    config_file.add_category('CategoryA', aggregation_mode)
+    config_file.add_plugin('CategoryA',
+                           'PluginA',
+                           {'rare': {'score': 2, 'lower': 0.01, 'upper': 0.05}},
+                           'plugin_a')
+    config_file.add_plugin('CategoryA',
+                           'PluginB',
+                           {'rare': {'score': -5, 'lower': 4.0, 'upper': 6.0}},
+                           'plugin_b')
+    config_parser: ConfigParser = ConfigParser(config_file.filename)
+    # WHEN scoring a variant
+    score, min, max = get_category_score(variant=variant_0,
+                                         category='CategoryA',
+                                         config_parser=config_parser)
+    # THEN expect proper score and min max bounds
+    assert score == expected[0]
+    assert min == expected[1]
+    assert max == expected[2]
+
+
+@pytest.mark.parametrize('aggregation_mode,expected',
+                         [('sum', (2, 0, 2)),
+                          ('max', (2, 0, 2)),
+                          ('min', (2, 0, 2))])
+def test_multi_category_two_plugins(config_file, variant_0, aggregation_mode, expected):
+    """
+    Test with a single category, shall ignore other category
+    """
+    # GIVEN a scoring config in mode aggregation_mode
+    config_file.add_category('CategoryA', aggregation_mode)
+    config_file.add_category('CategoryB', aggregation_mode)
+    config_file.add_plugin('CategoryA',
+                           'PluginA',
+                           {'rare': {'score': 2.0, 'lower': 0.01, 'upper': 0.05}},
+                           'plugin_a')
+    config_file.add_plugin('CategoryB',
+                           'PluginB',
+                           {'rare': {'score': 1.0, 'lower': 4.0, 'upper': 6.0}},
+                           'plugin_b')
+    config_parser: ConfigParser = ConfigParser(config_file.filename)
+    # WHEN scoring a variant, expect only from category A
+    score, min, max = get_category_score(variant=variant_0,
+                                         category='CategoryA',
+                                         config_parser=config_parser)
+    # THEN expect proper score and min max bounds
+    assert score == expected[0]
+    assert min == expected[1]
+    assert max == expected[2]
+
+@pytest.mark.parametrize('aggregation_mode,expected',
+                         [('sum', (10, 0, 10)),
+                          ('max', (10, 0, 10)),
+                          ('min', (10, 0, 10))])
+def test_single_category_single_plugin_multirange(config_file, variant_0, aggregation_mode, expected):
+    """
+    Test with a single category, having multiple score ranges.
+    """
+    # GIVEN a scoring config in mode aggregation_mode
+    config_file.add_category('CategoryA', aggregation_mode)
+    config_file.add_plugin('CategoryA',
+                           'PluginA',
+                           {'rare': {'score': 10.0, 'lower': 0.01, 'upper': 0.05},
+                            'common': {'score': 1.0, 'lower': 0.06, 'upper': 1.0}},
+                           'plugin_a')
+    config_parser: ConfigParser = ConfigParser(config_file.filename)
+    # WHEN scoring a variant
+    score, min, max = get_category_score(variant=variant_0,
+                                         category='CategoryA',
+                                         config_parser=config_parser)
+    # THEN expect proper score and min max bounds
+    assert score == expected[0]
+    assert min == expected[1]
+    assert max == expected[2]

--- a/tests/score_variants/test_rankscore_capping.py
+++ b/tests/score_variants/test_rankscore_capping.py
@@ -1,0 +1,31 @@
+from genmod.score_variants.cap_rank_score_to_min_bound import cap_rank_score_to_min_bound, MIN_SCORE_NORMALIZED
+
+
+MIN_SCORE: float = -5.0
+
+
+def test_rankscore_normalized_capping():
+    """
+    Test the MIN normalization bounds capping of rankscore normalized.
+    """
+    # GIVEN a normalized rank score
+    # WHEN running cap method
+    # THEN expect rank score to be larger than min bound
+    for rank_score_normalized in range(-10, 10):
+        assert cap_rank_score_to_min_bound(rank_score_type='RankScoreNormalized',
+                                           rank_score=float(rank_score_normalized),
+                                           min_rank_score_value=MIN_SCORE_NORMALIZED) >= MIN_SCORE_NORMALIZED
+
+
+def test_rankscore_capping():
+    """
+    Test the MIN normalization bounds capping of rankscore.
+    """
+
+    # GIVEN a rank score
+    # WHEN running cap method
+    # THEN expect rank score to be larger than min bound
+    for rank_score in range(-10, 10):
+        assert cap_rank_score_to_min_bound(rank_score_type='RankScore',
+                                           rank_score=rank_score,
+                                           min_rank_score_value=MIN_SCORE) >= MIN_SCORE

--- a/tests/utils/test_get_rank_score.py
+++ b/tests/utils/test_get_rank_score.py
@@ -1,5 +1,6 @@
 from genmod.utils import get_rank_score
 from genmod.vcf_tools import get_variant_dict, get_info_dict
+from genmod.score_variants.rank_score_variant_definitions import RANK_SCORE_TYPE_NAMES
 
 def get_variant_line():
     """Return a vcf formatted variant line."""
@@ -8,7 +9,7 @@ def get_variant_line():
 def test_get_rank_score():
     """docstring for test_get_rank_score"""
     variant_line = "1\t879537\t.\tT\tC\t100\tPASS\tMQ=1;GeneticModels=1:AR_hom;"\
-    "ModelScore=1:55;Annotation=SAMD11;CADD=1.248;Exonic;RankScore=1:23\t"\
+    "ModelScore=1:55;Annotation=SAMD11;CADD=1.248;Exonic;RankScore=1:23;RankScoreNormalized=1:0.2\t"\
     "GT:AD:GQ\t0/1:10,10:60"
     
     assert float(get_rank_score(variant_line = variant_line)) == float('23')
@@ -18,13 +19,14 @@ def test_get_rank_score_no_score():
     variant_line = "1\t879537\t.\tT\tC\t100\tPASS\tMQ=1;GeneticModels=1:AR_hom;"\
     "ModelScore=1:55;Annotation=SAMD11;CADD=1.248;Exonic\t"\
     "GT:AD:GQ\t0/1:10,10:60"
-    
-    assert float(get_rank_score(variant_line = variant_line)) == float('-100')
+
+    for rank_score_type in RANK_SCORE_TYPE_NAMES:
+        assert float(get_rank_score(variant_line=variant_line, rank_score_type=rank_score_type)) == float('-100')
 
 def test_get_rank_score_multiple_families():
     """docstring for test_get_rank_score"""
     variant_line = "1\t879537\t.\tT\tC\t100\tPASS\tMQ=1;GeneticModels=1:AR_hom;"\
-    "ModelScore=1:55;Annotation=SAMD11;CADD=1.248;Exonic;RankScore=1:23,2:12\t"\
+    "ModelScore=1:55;Annotation=SAMD11;CADD=1.248;Exonic;RankScore=1:23,2:12;RankScoreNormalized=1:0.2\t"\
     "GT:AD:GQ\t0/1:10,10:60"
     
     assert float(get_rank_score(variant_line = variant_line, family_id='2')) == float('12')
@@ -33,7 +35,7 @@ def test_get_rank_score_dict():
     """docstring for test_get_rank_score"""
     header_line = "CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t1"
     variant_info = "1\t879537\t.\tT\tC\t100\tPASS\tMQ=1;GeneticModels=1:AR_hom;"\
-    "ModelScore=1:55;Annotation=SAMD11;CADD=1.248;Exonic;RankScore=1:23\t"\
+    "ModelScore=1:55;Annotation=SAMD11;CADD=1.248;Exonic;RankScore=1:23;RankScoreNormalized=1:0.2\t"\
     "GT:AD:GQ\t0/1:10,10:60"
     variant_dict = get_variant_dict(
         variant_line=variant_info, 
@@ -43,3 +45,14 @@ def test_get_rank_score_dict():
     variant_dict['info_dict'] = get_info_dict(variant_dict['INFO'])
     
     assert float(get_rank_score(variant_dict = variant_dict)) == float('23')
+
+
+def test_get_rank_score_normalized():
+    """ Test fetching normalized rank score form VCF INFO field """
+    # GIVEN an INFO field string with both raw and normalized rank score
+    variant_line = "1\t879537\t.\tT\tC\t100\tPASS\tMQ=1;GeneticModels=1:AR_hom;" \
+                   "ModelScore=1:55;Annotation=SAMD11;CADD=1.248;Exonic;RankScore=1:23;RankScoreNormalized=1:0.2\t" \
+                   "GT:AD:GQ\t0/1:10,10:60"
+    # WHEN fetching normalized rank score
+    # THEN expect correct value fetched
+    assert float(get_rank_score(variant_line=variant_line, rank_score_type='RankScoreNormalized')) == 0.2


### PR DESCRIPTION
# Rank Score Normalization

Additions to scored VCF file:
* RankScoreNormalized
* RankScoreMinMax
* CompoundsNormalized

## TODOs

Current tests in this repo does not cover all plugins, categories
used by MIP pipeline. Determine a strategy for testing this PR. 

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
- `make test` but this does not cover CompoundScore.

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
