### PR TITLE
set abstract_sockets_supported to False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Please add a new candidate release at the top after changing the latest one. Fee
 
 Try to use the following format:
 
+## [3.7.4]
+
+### Fixed
+- OSError crashes due to socket address conflicts when using containers
+
 ## [x.x.x]
 
 ### Changed

--- a/genmod/commands/annotate_models.py
+++ b/genmod/commands/annotate_models.py
@@ -21,7 +21,7 @@ import logging
 import shutil
 import itertools
 
-from multiprocessing import JoinableQueue, Manager, cpu_count
+from multiprocessing import JoinableQueue, Manager, cpu_count, util
 from codecs import open
 from datetime import datetime
 from tempfile import NamedTemporaryFile
@@ -39,6 +39,7 @@ from .utils import (temp_dir, silent, outfile, processes, variant_file,
                     family_file, family_type, get_file_handle)
 
 logger = logging.getLogger(__name__)
+util.abstract_sockets_supported = False
 
 @click.command('models', short_help="Annotate inheritance")
 @variant_file

--- a/genmod/commands/score_compounds.py
+++ b/genmod/commands/score_compounds.py
@@ -17,7 +17,7 @@ import click
 import logging
 import itertools
 
-from multiprocessing import JoinableQueue, Manager, cpu_count
+from multiprocessing import JoinableQueue, Manager, cpu_count, util
 from codecs import open
 from datetime import datetime
 from tempfile import NamedTemporaryFile
@@ -33,6 +33,7 @@ from .utils import (variant_file, silent, outfile, processes, temp_dir,
                     get_file_handle)
 
 logger = logging.getLogger(__name__)
+util.abstract_sockets_supported = False
 
 @click.command('compound', short_help="Score compounds")
 @variant_file

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ except (IOError, ImportError, RuntimeError):
     long_description = 'Tool for annotating patterns of genetic inheritance in Variant Call Format (VCF) files.'
 
 setup(name='genmod',
-    version='3.7.3',
+    version='3.7.4',
     description='Annotate genetic inheritance models in variant files',
     author = 'Mans Magnusson',
     author_email = 'mans.magnusson@scilifelab.se',

--- a/tests/utils/test_variant_printer.py
+++ b/tests/utils/test_variant_printer.py
@@ -1,13 +1,13 @@
 from codecs import open
 from tempfile import NamedTemporaryFile
-from multiprocessing import Manager
+from multiprocessing import Manager, util
 from collections import OrderedDict
 
 from genmod.utils import VariantPrinter
 from genmod.vcf_tools import (get_variant_dict, get_info_dict, 
 get_variant_id, HeaderParser)
 
-
+util.abstract_sockets_supported = False
 
 def setup_vcf_file():
     """


### PR DESCRIPTION
Re-runs of genmod on the same cases when using singularity containers were crashing due to OSError 
<img width="640" alt="Screenshot 2023-08-26 at 14 00 20" src="https://github.com/Clinical-Genomics/genmod/assets/20065894/fee6349b-bdef-42bf-8423-63d35a888815">

Turns out this error is very likely to be caused by multiprocessing.Manager(), because its default socket address on Unix machines is not very random. So multiple containers on the same machine might be trying to access the same address resulting in memory conflicts. Changes proposed in this PR should fix that. 

More info: https://stackoverflow.com/questions/74058016/how-do-you-run-multiple-aws-batch-jobs-with-multiprocessing-mp-manager-witho



### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
