### PR TITLE
setup.py: Lockdown genmod, limit compatibility to python v3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(name='genmod',
     author_email = 'mans.magnusson@scilifelab.se',
     url = 'http://github.com/moonso/genmod',
     license = 'MIT License',
+    python_requires="~=3.8.0",
     install_requires=[
         'ped_parser >= 1.6.6',
         'pytabix >= 0.1',


### PR DESCRIPTION
This is the currently only tested, supported python version.

No other versions of python are currently supported.

Signed-off-by: Tor Björgen <tor.bjorgen@scilifelab.se>
