### PR TITLE
Fixup wrongly annotated VCF in test/fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Try to use the following format:
 ### Fixed 
 - Add scoring normalisation for flag lookup mode ([#177](https://github.com/Clinical-Genomics/genmod/pull/177))
 - Fix crash on test for missing annotation key for phased mode ([#178](https://github.com/Clinical-Genomics/genmod/pull/178))
+- Correct test VCF file that contained prematurely added Compounds annotation ([#179](https://github.com/Clinical-Genomics/genmod/pull/179))
 
 ## [3.10.1]
 ### Fixed

--- a/tests/fixtures/test_vcf_annotated.vcf
+++ b/tests/fixtures/test_vcf_annotated.vcf
@@ -1,7 +1,6 @@
 ##fileformat=VCFv4.1
 ##INFO=<ID=GeneticModels,Number=.,Type=String,Description="':'-separated list of genetic models for this variant.">
 ##INFO=<ID=ModelScore,Number=1,Type=Integer,Description="PHRED score for genotype models.">
-##INFO=<ID=Compounds,Number=.,Type=String,Description="List of compound pairs for this variant.The list is splitted on ',' family id is separated with compoundswith ':'. Compounds are separated with '|'.">
 ##INFO=<ID=Annotation,Number=.,Type=String,Description="Annotates what feature(s) this variant belongs to.">
 ##INFO=<ID=CADD,Number=A,Type=Float,Description="The CADD relative score for this alternative.">
 ##INFO=<ID=1000GAF,Number=A,Type=Float,Description="Frequency in the 1000G database.">
@@ -14,13 +13,13 @@
 1	879541	.	G	A	100	PASS	MQ=1;GeneticModels=1:AR_hom|AR_hom_dn;ModelScore=1:57;Annotation=SAMD11;CADD=4.003;1000GAF=0.000599042	GT:AD:GQ	./.	0/1:10,10:60	1/1:10,10:60	./.	0/1:10,10:60	0/1:10,10:60
 1	879595	.	C	T	100	PASS	MQ=1;GeneticModels=1:AR_hom_dn;ModelScore=1:55;Annotation=NOC2L,SAMD11;CADD=8.271;1000GAF=0.000399361	GT:AD:GQ	0/1:10,10:60	0/0:10,10:60	1/1:10,10:60	0/1:10,10:60	0/0:10,10:60	0/1:10,10:60
 1	879676	.	G	A	100	PASS	MQ=1;Annotation=NOC2L,SAMD11;CADD=7.019;1000GAF=0.885982	GT:AD:GQ	0/1:10,10:60	1/1:10,10:60	1/1:10,10:60	0/1:10,10:60	0/1:10,10:60	0/1:10,10:60
-1	879911	.	G	A	100	PASS	MQ=1;Compounds=1:1_880086_T_C|1_880012_A_G;GeneticModels=1:AR_comp|AR_comp_dn;ModelScore=1:55;Annotation=NOC2L,SAMD11;CADD=4.408;1000GAF=0.00998403	GT:AD:GQ	0/1:10,10:60	0/0:10,10:60	0/1:10,10:60	0/1:10,10:60	0/0:10,10:60	0/1:10,10:60
-1	880012	.	A	G	100	PASS	MQ=1;Compounds=1:1_880086_T_C|1_879911_G_A;GeneticModels=1:AR_comp|AR_comp_dn;ModelScore=1:55;Annotation=NOC2L;CADD=3.326;1000GAF=0.00119808	GT:AD:GQ	0/0:10,10:60	0/1:10,10:60	0/1:10,10:60	0/0:10,10:60	0/1:10,10:60	0/1:10,10:60
-1	880086	.	T	C	100	PASS	MQ=1;Compounds=1:1_880012_A_G|1_879911_G_A;GeneticModels=1:AR_comp_dn|AD_dn;ModelScore=1:55;Annotation=NOC2L;CADD=0.091;1000GAF=0.000399361	GT:AD:GQ	0/0:10,10:60	0/0:10,10:60	0/1:10,10:60	0/0:10,10:60	0/0:10,10:60	0/1:10,10:60
+1	879911	.	G	A	100	PASS	MQ=1;GeneticModels=1:AR_comp|AR_comp_dn;ModelScore=1:55;Annotation=NOC2L,SAMD11;CADD=4.408;1000GAF=0.00998403	GT:AD:GQ	0/1:10,10:60	0/0:10,10:60	0/1:10,10:60	0/1:10,10:60	0/0:10,10:60	0/1:10,10:60
+1	880012	.	A	G	100	PASS	MQ=1;GeneticModels=1:AR_comp|AR_comp_dn;ModelScore=1:55;Annotation=NOC2L;CADD=3.326;1000GAF=0.00119808	GT:AD:GQ	0/0:10,10:60	0/1:10,10:60	0/1:10,10:60	0/0:10,10:60	0/1:10,10:60	0/1:10,10:60
+1	880086	.	T	C	100	PASS	MQ=1;GeneticModels=1:AR_comp_dn|AD_dn;ModelScore=1:55;Annotation=NOC2L;CADD=0.091;1000GAF=0.000399361	GT:AD:GQ	0/0:10,10:60	0/0:10,10:60	0/1:10,10:60	0/0:10,10:60	0/0:10,10:60	0/1:10,10:60
 1	880199	.	G	A	100	PASS	MQ=1;GeneticModels=1:AD_dn;ModelScore=1:55;Annotation=NOC2L;CADD=3.450	GT:AD:GQ	0/0:10,10:60	0/0:10,10:60	0/1:10,10:60	0/0:10,10:60	0/0:10,10:60	0/1:10,10:60
 1	880217	.	T	G	100	PASS	MQ=1;GeneticModels=1:AD_dn;ModelScore=1:55;Annotation=NOC2L;CADD=4.208	GT:AD:GQ	0/0:10,10:60	0/0:10,10:60	0/1:10,10:60	0/0:10,10:60	0/0:10,10:60	0/1:10,10:60
-10	76154051	.	A	G	100	PASS	MQ=1;Compounds=1:10_76154073_T_G;GeneticModels=1:AR_comp_dn;ModelScore=1:55;Annotation=ADK;CADD=9.261;1000GAF=0.000199681	GT:AD:GQ	0/0:10,10:60	0/1:10,10:60	0/1:10,10:60	0/0:10,10:60	0/1:10,10:60	0/1:10,10:60
-10	76154073	.	T	G	100	PASS	MQ=1;Compounds=1:10_76154051_A_G;GeneticModels=1:AR_comp_dn|AD_dn;ModelScore=1:55;Annotation=ADK;CADD=22.4	GT:AD:GQ	0/0:10,10:60	0/0:10,10:60	0/1:10,10:60	0/0:10,10:60	0/0:10,10:60	0/1:10,10:60
+10	76154051	.	A	G	100	PASS	MQ=1;GeneticModels=1:AR_comp_dn;ModelScore=1:55;Annotation=ADK;CADD=9.261;1000GAF=0.000199681	GT:AD:GQ	0/0:10,10:60	0/1:10,10:60	0/1:10,10:60	0/0:10,10:60	0/1:10,10:60	0/1:10,10:60
+10	76154073	.	T	G	100	PASS	MQ=1;GeneticModels=1:AR_comp_dn|AD_dn;ModelScore=1:55;Annotation=ADK;CADD=22.4	GT:AD:GQ	0/0:10,10:60	0/0:10,10:60	0/1:10,10:60	0/0:10,10:60	0/0:10,10:60	0/1:10,10:60
 10	76154074	.	C	G	100	PASS	MQ=1;Annotation=ADK;CADD=8.374	GT:AD:GQ	./.	0/1:10,10:60	0/1:10,10:60	0/1:10,10:60	0/1:10,10:60	0/1:10,10:60
 10	76154076	.	G	C	100	PASS	MQ=1;GeneticModels=1:AD|AD_dn;ModelScore=1:57;Annotation=ADK;CADD=11.65	GT:AD:GQ	./.	0/0:10,10:60	0/1:10,10:60	./.	0/0:10,10:60	0/1:10,10:60
 X	302253	.	CCCTCCTGCCCCT	C	100	PASS	MQ=1;GeneticModels=1:XD|XR;ModelScore=1:55;Annotation=PPP2R3B;1000GAF=0.04	GT:AD:GQ	0/0:10,10:60	0/1:10,10:60	1/1:10,10:60	0/0:10,10:60	1/1:10,10:60	1/1:10,10:60


### PR DESCRIPTION
'Compounds' annotation is prematurely added in this file, since
there's no RankScore available (prerequisite to compound scoring).

Signed-off-by: Tor Björgen <tor.bjorgen@scilifelab.se>
